### PR TITLE
feat: validate before going to next step

### DIFF
--- a/src/Components/StepComponent.php
+++ b/src/Components/StepComponent.php
@@ -21,6 +21,10 @@ abstract class StepComponent extends Component
 
     public function nextStep()
     {
+        if (! empty($this->getRules())) {
+            $this->validate();
+        }
+
         $this->emitUp('nextStep', $this->currentStepState());
     }
 

--- a/tests/ComponentTest.php
+++ b/tests/ComponentTest.php
@@ -3,6 +3,7 @@
 use Livewire\Livewire;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\MyWizardComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\StepWithValidationComponent;
 
 it('can render a wizard component', function () {
     Livewire::test(MyWizardComponent::class)->assertSuccessful();
@@ -10,4 +11,19 @@ it('can render a wizard component', function () {
 
 it('can render a step component', function () {
     Livewire::test(FirstStepComponent::class)->assertSuccessful();
+});
+
+it('emits next step event', function () {
+    Livewire::test(FirstStepComponent::class)
+        ->call('nextStep')
+        ->assertHasNoErrors()
+        ->assertEmittedUp('nextStep');
+});
+
+it('can validate state before next step', function () {
+    Livewire::test(StepWithValidationComponent::class)
+        ->call('nextStep')
+        ->assertHasErrors([
+            'name' => 'required'
+        ]);
 });

--- a/tests/TestSupport/Components/Steps/StepWithValidationComponent.php
+++ b/tests/TestSupport/Components/Steps/StepWithValidationComponent.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace Spatie\LivewireWizard\Tests\TestSupport\Components\Steps;
+
+use Spatie\LivewireWizard\Components\StepComponent;
+
+class StepWithValidationComponent extends StepComponent
+{
+    public string $name = '';
+
+    public array $rules = [
+        'name' => 'required',
+    ];
+
+    public function render()
+    {
+        return '';
+    }
+}


### PR DESCRIPTION
I'm not 100% sure about this myself, that's why I switched the PR to draft. The reason I PR'd this was because we use it in our own wizard too. Our wizard has a completely different approach though. 

How much additional logic like this are you willing to accept? As you could just implement `next()` and `back()` methods yourself and have it call `nextStep()` or `previousStep()`.

```php
function next()
{
    $this->validate();
    $this->nextStep();
}
```

In our wizard we have implemented validation and storing data within the step-buttons, but it might make more sense to leave it as is and have users implement additional actions (e.g. storing and such) in their own steps.