### PR TITLE
feat: add support for shouldSkip

### DIFF
--- a/src/Components/Concerns/StepAware.php
+++ b/src/Components/Concerns/StepAware.php
@@ -12,12 +12,6 @@ trait StepAware
     {
         $currentFound = false;
 
-        if (method_exists($this, 'shouldSkip') && $this->shouldSkip()) {
-            $this->nextStep();
-
-            return;
-        }
-
         $currentStepName = Livewire::getAlias(static::class);
 
         $this->steps = collect($this->allStepNames)

--- a/tests/SkipStepTest.php
+++ b/tests/SkipStepTest.php
@@ -1,0 +1,23 @@
+<?php
+
+use Livewire\Livewire;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SkipStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\WizardWithSkippedStepComponent;
+
+beforeEach(function () {
+    $this->wizard = Livewire::test(WizardWithSkippedStepComponent::class);
+    $this->firstStep = Livewire::test(FirstStepComponent::class);
+    $this->skipStep = Livewire::test(SkipStepComponent::class);
+});
+
+it('skips the step when shouldSkip returns true', function () {
+    $wizard = $this->wizard->assertSee('first step');
+
+    $this->firstStep
+        ->assertSuccessful()
+        ->call('nextStep')
+        ->emitEvents()->in($wizard);
+
+    $wizard->assertSee('third step');
+});

--- a/tests/TestSupport/Components/Steps/SkipStepComponent.php
+++ b/tests/TestSupport/Components/Steps/SkipStepComponent.php
@@ -1,0 +1,22 @@
+<?php
+
+namespace Spatie\LivewireWizard\Tests\TestSupport\Components\Steps;
+
+use Spatie\LivewireWizard\Components\StepComponent;
+
+class SkipStepComponent extends StepComponent
+{
+    public function shouldSkip(): bool
+    {
+        return true;
+    }
+
+    public function render()
+    {
+        return <<<'blade'
+            <div>
+            Skip this step.
+            </div>
+        blade;
+    }
+}

--- a/tests/TestSupport/Components/WizardWithSkippedStepComponent.php
+++ b/tests/TestSupport/Components/WizardWithSkippedStepComponent.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Spatie\LivewireWizard\Tests\TestSupport\Components;
+
+use Spatie\LivewireWizard\Components\WizardComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SkipStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\ThirdStepComponent;
+
+class WizardWithSkippedStepComponent extends WizardComponent
+{
+    public function steps(): array
+    {
+        return [
+            FirstStepComponent::class,
+            SkipStepComponent::class,
+            ThirdStepComponent::class,
+        ];
+    }
+}

--- a/tests/TestSupport/TestCase.php
+++ b/tests/TestSupport/TestCase.php
@@ -14,6 +14,7 @@ use Spatie\LivewireWizard\Components\WizardComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\CustomStateStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SecondStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SkipStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\ThirdStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Support\EventEmitter;
 use Spatie\LivewireWizard\WizardServiceProvider;
@@ -49,6 +50,7 @@ class TestCase extends Orchestra
         Livewire::component('second-step', SecondStepComponent::class);
         Livewire::component('third-step', ThirdStepComponent::class);
         Livewire::component('custom-state-step', CustomStateStepComponent::class);
+        Livewire::component('skip-step', SkipStepComponent::class);
 
         return $this;
     }


### PR DESCRIPTION
Some notes.

This is a different (and much better!) implementation of `shouldSkip`. It does not depend on events which allows for skipping steps without an additional network round-trip. Better end-user UX, hooray!

- The `getLivewireInstance()` method is a partial implementation of what happens in `Livewire::mount()`.
- It does not yet pass state to the component. We 100% need this, but I am not completely sure what state to pass yet.
- `getLivewireInstance` is not the same as `getInstance` in Livewire.
- It might be cleaner to add it as a macro to `Livewire`. This can be changed of course.

It doesn't support excluding `shouldSkip`'ed steps from the navigation. This needs a new PR. And I'm out of time :)