### PR TITLE
chore: remove old code

### DIFF
--- a/src/Components/Concerns/StepAware.php
+++ b/src/Components/Concerns/StepAware.php
@@ -12,12 +12,6 @@ trait StepAware
     {
         $currentFound = false;
 
-        if (method_exists($this, 'shouldSkip') && $this->shouldSkip()) {
-            $this->nextStep();
-
-            return;
-        }
-
         $currentStepName = Livewire::getAlias(static::class);
 
         $this->steps = collect($this->allStepNames)


### PR DESCRIPTION
The initial `shouldSkip` implementation didn't work and was removed. As `shouldSkip` does not work in this trait, this code should be removed too.