### PR TITLE
refactor: move logic into dedicated method

### DIFF
--- a/src/Components/WizardComponent.php
+++ b/src/Components/WizardComponent.php
@@ -101,9 +101,9 @@ abstract class WizardComponent extends Component
         $this->allStepState[$step] = $state;
     }
 
-    public function render()
+    public function getCurrentStepState(): array
     {
-        $currentStepState = array_merge(
+        return array_merge(
             $this->allStepState[$this->currentStepName] ?? [],
             [
                 'allStepNames' => $this->stepNames()->toArray(),
@@ -111,6 +111,11 @@ abstract class WizardComponent extends Component
                 'stateClassName' => $this->stateClass(),
             ],
         );
+    }
+
+    public function render()
+    {
+        $currentStepState = $this->getCurrentStepState();
 
         return view('livewire-wizard::wizard', compact('currentStepState'));
     }


### PR DESCRIPTION
Moving $currentStepState into its own method allows for changes down the road. This allows developers to implement their own render method, without having to worry about changes in $currentStepState upstream.

No tests changed/added as state is already thoroughly covered.