### PR TITLE
feat: make wizards testable

### DIFF
--- a/docs/usage/testing-wizards.md
+++ b/docs/usage/testing-wizards.md
@@ -3,19 +3,15 @@ title: Testing wizards
 weight: 6
 ---
 
-Livewire has an extensive set of testing utilities; we offer a few more to 
-test your wizards.
+On this page we'll show you a few tips on how to tests wizards created with this package.
 
-## Internals
+## A peek under the hood
 
-Let's briefly touch on some of the internals.
+To understand how you should test a wizard, you should know how it works under the hood. Let's take a look!
 
-A wizard keeps track of its steps and state. To make your wizard easy to 
-navigate, an event is emitted to the wizard when you call `nextStep` or
-`previousStep`. This event will also contain the state of the step it is called
-from.
+A wizard keeps track of its steps and state. An event is emitted from a `StepComponent` to a `WizardComponent` when you call `nextStep` (or related functions). This event will contain the state of the step it is called from.
 
-The wizard will receive the event and shows you the page you requested, along
+The wizard will receive the event and shows you the step you requested, along
 with the state for that step. If you're familiar with Livewire, the wizard
 renders a component like this:
 
@@ -26,19 +22,14 @@ renders a component like this:
 As a wizard and its steps are tightly coupled, it's not always useful to test
 individual components. They don't paint the full picture.
 
-Testing your wizard needs some magic. Because well, wizards do magic.
+## Testing navigation of the wizard
 
-## Navigating your wizard
+When testing a wizard- or step-component, you may make use of the `emitsEvents()`
+ method provided by our package.
+ 
+`emitEvents` allows you to take all events from a `StepComponent` and fire them in the `WizardComponent`. 
 
-Navigating your wizard is done with events. The browser uses Javascript to
-pass them to the respective component. This means you either need to use Dusk
-to navigate, or use a method called `emitEvents`.
-
-`emitEvents` allows you to take all events from a `StepComponent` and make
-them available for your wizard. Without it, you would only be able to test
-your components by themselves.
-
-Below is an example of its use; we use something similar in our own tests.
+Here's an example:
 
 ```php
 $wizard = Livewire::test(CartWizard::class);
@@ -52,7 +43,7 @@ Livewire::test(ShowCartStep::class)
 $wizard->assertSee('fill in your address');
 ```
 
-ShowCartStep shows the contents of a customers cart and is the first step of
+`ShowCartStep` shows the contents of a customers cart and is the first step of
 our wizard. The next step, although the class is not shown here, is to fill in
 your address details.
 
@@ -61,19 +52,14 @@ loaded correctly. A simple test is to assert that a string is visible. In this
 case, we assert that it shows 'cart'.
 
 We then move to the next step by calling `nextStep`. This emits an event to be
-picked up by the wizard. This usually depends on JavaScript in the browser, to
-simulate this in your test, you can use `emitEvents`.
+picked up by the wizard. `emitEvents` takes the event thats emitted by `nextStep` and passes it to the
+wizard. The wizard processes it and takes you to the next step. We then assert if the second step is loaded.
 
-`emitEvents` takes the event thats emitted by `nextStep` and passes it to the
-wizard. The wizard processes it and takes you to the next step.
+## Testing state in a `StepComponent`
 
-We then assert if the second step is loaded.
+Now that you know how to navigate your wizard in your tests, let's talk state. 
 
-## Testing state in a StepComponent
-
-Now you know how to navigate your wizard in your tests, let's talk state. 
-
-State is stored in the wizard and each step by its own has no idea or access to
+State is stored in the wizard. Each step by its own has no idea or access to
 it. In a browser, state is passed to steps automatically, but in your tests you
 need `getStepState` to fetch the state from the wizard and pass it to a step.
 
@@ -81,7 +67,7 @@ We go back to our cart wizard where we want to test state. Our example is a
 simple one, but this can be used to test your final step where you're 
 processing your cart.
 
-We're going to emulate ordering Spatie's Laravel Comments. `initialState` is 
+We're going to emulate ordering [Laravel Comments](https://laravel-comments.com). `initialState` is 
 used to populate the cart. We're not implementing the address step here and
 go straight to checkout.
 

--- a/docs/usage/testing-wizards.md
+++ b/docs/usage/testing-wizards.md
@@ -42,7 +42,7 @@ $wizard->assertSee('fill in your address');
 `emitEvents` takes the event thats emitted by `nextStep` and passes it to the
 wizard. The wizard processes it and takes you to the next step.
 
-## Passing state to components
+## Testing state in a StepComponent
 
 Now you know how to navigate your wizard in your tests, let's talk state. 
 

--- a/docs/usage/testing-wizards.md
+++ b/docs/usage/testing-wizards.md
@@ -46,9 +46,9 @@ wizard. The wizard processes it and takes you to the next step.
 
 Now you know how to navigate your wizard in your tests, let's talk state. 
 
-We have a cart wizard. The initial state of this cart is a list of items, made
-available to the `show-cart-step`. We want to be sure this step has access to
-those items. The cart has only one item, Spatie's Laravel Comments.
+Let's say We have a cart wizard. The initial state of this cart is a list of 
+items, made available to the `show-cart-step`. We want to be sure this step has 
+access to those items. The cart has only one item, Spatie's Laravel Comments.
 
 `getStateForStep` allows you to get state for a step from a wizard. The example
 below shows how you can test if the cart contains the item you expect.
@@ -69,3 +69,4 @@ $showCartState = $wizard->getStateForStep('show-cart-step');
 Livewire::test(ShowCartStep::class, $showCartState)
     ->assertSet('items.0.detail', 'Laravel Comments');
 ```
+

--- a/docs/usage/testing-wizards.md
+++ b/docs/usage/testing-wizards.md
@@ -50,7 +50,7 @@ Let's say We have a cart wizard. The initial state of this cart is a list of
 items, made available to the `show-cart-step`. We want to be sure this step has 
 access to those items. The cart has only one item, Spatie's Laravel Comments.
 
-`getStateForStep` allows you to get state for a step from a wizard. The example
+`getStepState` allows you to get state for a step from a wizard. The example
 below shows how you can test if the cart contains the item you expect.
 
 ```php
@@ -64,7 +64,7 @@ $wizard = Livewire::test(CartWizard::class, [
     ],
 ]);
 
-$showCartState = $wizard->getStateForStep('show-cart-step');
+$showCartState = $wizard->getStepState('show-cart-step');
 
 Livewire::test(ShowCartStep::class, $showCartState)
     ->assertSet('items.0.detail', 'Laravel Comments');

--- a/docs/usage/testing-wizards.md
+++ b/docs/usage/testing-wizards.md
@@ -1,0 +1,71 @@
+---
+title: Testing wizards
+weight: 6
+---
+
+Livewire has an extensive set of testing utilities; we offer a few more to 
+test your wizards.
+
+## Internals
+
+Let's briefly touch on some of the internals.
+
+A wizard keeps track of its steps. Navigating through a wizard is based on
+events. Once you `nextStep` in one of your steps, it emits up to your wizard, 
+with the state of that step as its parameter.
+
+When the next step is loaded, its state gets passed. The `StepComponent` will
+process it and make it available for you to display.
+
+Testing your wizard needs some magic. Because well, wizards do magic.
+
+## Navigating your wizard
+
+`emitEvents` allows you to take all events from a `StepComponent` and can make
+them available for your wizard. Without it, you would only be able to test
+your components by themselves.
+
+Below is an example of its use; we use something similar in our own tests.
+
+```php
+$wizard = Livewire::test(CartWizard::class);
+
+$wizard->assertSee('cart');
+
+Livewire::test(ShowCartStep::class)
+    ->call('nextStep')
+    ->emitEvents()->in($wizard);
+
+$wizard->assertSee('fill in your address');
+```
+
+`emitEvents` takes the event thats emitted by `nextStep` and passes it to the
+wizard. The wizard processes it and takes you to the next step.
+
+## Passing state to components
+
+Now you know how to navigate your wizard in your tests, let's talk state. 
+
+We have a cart wizard. The initial state of this cart is a list of items, made
+available to the `show-cart-step`. We want to be sure this step has access to
+those items. The cart has only one item, Spatie's Laravel Comments.
+
+`getStateForStep` allows you to get state for a step from a wizard. The example
+below shows how you can test if the cart contains the item you expect.
+
+```php
+$wizard = Livewire::test(CartWizard::class, [
+    'show-cart-step' => [
+        'items' => [
+            0 => [
+                'detail' => 'Laravel Comments'
+            ],
+        ],
+    ],
+]);
+
+$showCartState = $wizard->getStateForStep('show-cart-step');
+
+Livewire::test(ShowCartStep::class, $showCartState)
+    ->assertSet('items.0.detail', 'Laravel Comments');
+```

--- a/docs/usage/testing-wizards.md
+++ b/docs/usage/testing-wizards.md
@@ -14,14 +14,14 @@ A wizard keeps track of its steps. Navigating through a wizard is based on
 events. Once you `nextStep` in one of your steps, it emits up to your wizard, 
 with the state of that step as its parameter.
 
-When the next step is loaded, its state gets passed. The `StepComponent` will
-process it and make it available for you to display.
+When the next step is loaded, its state gets passed by the wizard. The 
+`StepComponent` will asign state to its properties.
 
 Testing your wizard needs some magic. Because well, wizards do magic.
 
 ## Navigating your wizard
 
-`emitEvents` allows you to take all events from a `StepComponent` and can make
+`emitEvents` allows you to take all events from a `StepComponent` and make
 them available for your wizard. Without it, you would only be able to test
 your components by themselves.
 
@@ -39,34 +39,63 @@ Livewire::test(ShowCartStep::class)
 $wizard->assertSee('fill in your address');
 ```
 
+ShowCartStep shows the contents of a customers cart and is the first step of
+our wizard. The next step, although the class is not shown here, is to fill in
+your address details.
+
+The wizard renders each step, so we first assert if the first step has been
+loaded correctly. A simple test is to assert that a string is visible. In this
+case, we assert that it shows 'cart'.
+
+We then move to the next step by calling `nextStep`. This emits an event to be
+picked up by the wizard. This usually depends on JavaScript in the browser, to
+simulate this in your test, you can use `emitEvents`.
+
 `emitEvents` takes the event thats emitted by `nextStep` and passes it to the
 wizard. The wizard processes it and takes you to the next step.
+
+We then assert if the second step is loaded.
 
 ## Testing state in a StepComponent
 
 Now you know how to navigate your wizard in your tests, let's talk state. 
 
-Let's say We have a cart wizard. The initial state of this cart is a list of 
-items, made available to the `show-cart-step`. We want to be sure this step has 
-access to those items. The cart has only one item, Spatie's Laravel Comments.
+We go back to our cart wizard. We want to test state. Our example is a simple
+one, but this can be used to test your final step where you're processing your
+cart.
 
-`getStepState` allows you to get state for a step from a wizard. The example
-below shows how you can test if the cart contains the item you expect.
+We're going to emulate ordering Spatie's Laravel Comments. `initialState` is 
+used to populate the cart. We're not implementing the address step here and
+go straight to checkout.
 
 ```php
-$wizard = Livewire::test(CartWizard::class, [
-    'show-cart-step' => [
-        'items' => [
-            0 => [
-                'detail' => 'Laravel Comments'
-            ],
+$initialState = 'show-cart-step' => [
+    'items' => [
+        0 => [
+            'detail' => 'Laravel Comments'
         ],
     ],
+],
+
+$wizard = Livewire::test(CartWizard::class, [
+    'initialState' => $initialState,  
 ]);
 
 $showCartState = $wizard->getStepState('show-cart-step');
 
 Livewire::test(ShowCartStep::class, $showCartState)
-    ->assertSet('items.0.detail', 'Laravel Comments');
+    ->assertSet('items.0.detail', 'Laravel Comments')
+    ->call('nextStep')
+    ->emitEvents()->in($wizard);
+
+$checkoutState = $wizard->getStepState('checkout-step');
+
+Livewire::test(CheckoutStep::class, $checkoutState)
+    ->call('placeOrder');
+
+$this->assertDatabaseHas(Order::class, [...]);
 ```
 
+This example illustrates how you can use `getStepState`. It will fetch the
+global state from the wizard so you can pass it on to your step's test. It
+makes it easy to work with real data and test your wizard completely.

--- a/src/Exceptions/StepDoesNotExist.php
+++ b/src/Exceptions/StepDoesNotExist.php
@@ -6,6 +6,11 @@ use Exception;
 
 class StepDoesNotExist extends Exception
 {
+    public static function stepNotFound(string $nonExistingStepName): self
+    {
+        return new static("Step `{$nonExistingStepName}` does not exist.");
+    }
+
     public static function doesNotHaveState(string $nonExistingStepName): self
     {
         return new static("Step `{$nonExistingStepName}` step does not exist and as such cannot have state.");

--- a/src/WizardServiceProvider.php
+++ b/src/WizardServiceProvider.php
@@ -30,7 +30,7 @@ class WizardServiceProvider extends PackageServiceProvider
             return new EventEmitter($this);
         });
 
-        TestableLivewire::macro('getStateForStep', function (string $step) {
+        TestableLivewire::macro('getStepState', function (string $step) {
             $state = $this->get('allStepState');
 
             $stepName = class_exists($step)

--- a/src/WizardServiceProvider.php
+++ b/src/WizardServiceProvider.php
@@ -2,8 +2,12 @@
 
 namespace Spatie\LivewireWizard;
 
+use Illuminate\Support\Arr;
+use Livewire\Livewire;
+use Livewire\Testing\TestableLivewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LivewireWizard\Tests\TestSupport\Support\EventEmitter;
 
 class WizardServiceProvider extends PackageServiceProvider
 {
@@ -12,5 +16,27 @@ class WizardServiceProvider extends PackageServiceProvider
         $package
             ->name('laravel-livewire-wizard')
             ->hasViews();
+    }
+
+    public function bootingPackage()
+    {
+        $this->registerLivewireTestMacros();
+    }
+
+    public function registerLivewireTestMacros()
+    {
+        TestableLivewire::macro('emitEvents', function () {
+            return new EventEmitter($this);
+        });
+
+        TestableLivewire::macro('getStateForStep', function (string $step) {
+            $state = $this->get('allStepState');
+
+            $stepName = class_exists($step)
+                ? Livewire::getAlias($step)
+                : $step;
+
+            return Arr::get($state, $stepName);
+        });
     }
 }

--- a/src/WizardServiceProvider.php
+++ b/src/WizardServiceProvider.php
@@ -7,6 +7,7 @@ use Livewire\Livewire;
 use Livewire\Testing\TestableLivewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
+use Spatie\LivewireWizard\Exceptions\StepDoesNotExist;
 use Spatie\LivewireWizard\Tests\TestSupport\Support\EventEmitter;
 
 class WizardServiceProvider extends PackageServiceProvider
@@ -36,7 +37,11 @@ class WizardServiceProvider extends PackageServiceProvider
                 ? Livewire::getAlias($step)
                 : $step;
 
-            return Arr::get($state, $stepName);
+            $state = Arr::get($state, $stepName);
+
+            throw_if(is_null($state), StepDoesNotExist::stepNotFound($step));
+
+            return $state;
         });
     }
 }

--- a/tests/InitialStateTest.php
+++ b/tests/InitialStateTest.php
@@ -1,6 +1,7 @@
 <?php
 
 use Livewire\Livewire;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\WizardWithInitialState;
 
 beforeEach(function () {
@@ -9,7 +10,7 @@ beforeEach(function () {
     ]);
 });
 
-it('can set initial state via a passed props', function () {
+it('can set initial state via passed props', function () {
     $this->wizard
         ->assertSuccessful()
         ->assertSet('allStepState', [
@@ -35,4 +36,30 @@ it('can handle manually passed in state', function () {
     ])
         ->assertSuccessful()
         ->assertSet('allStepState', $initialState);
+
+    $firstStepState = $this->wizard->getStateForStep(FirstStepComponent::class);
+
+    Livewire::test(FirstStepComponent::class, $firstStepState)
+        ->assertSuccessful()
+        ->assertSet('order', 123);
+});
+
+it('ignores initial state if property does not exist', function () {
+    $initialState = [
+        'first-step' => [
+            'name' => 'Freek',
+        ],
+    ];
+
+    $this->wizard = Livewire::test(WizardWithInitialState::class, [
+        'initialState' => $initialState,
+        'order' => 456, // will be ignored since initialState is passed
+    ])
+        ->assertSuccessful();
+
+    $firstStepState = $this->wizard->getStateForStep(FirstStepComponent::class);
+
+    Livewire::test(FirstStepComponent::class, $firstStepState)
+        ->assertSuccessful()
+        ->assertNotSet('name', 'Freek');
 });

--- a/tests/InitialStateTest.php
+++ b/tests/InitialStateTest.php
@@ -37,7 +37,7 @@ it('can handle manually passed in state', function () {
         ->assertSuccessful()
         ->assertSet('allStepState', $initialState);
 
-    $firstStepState = $this->wizard->getStateForStep(FirstStepComponent::class);
+    $firstStepState = $this->wizard->getStepState(FirstStepComponent::class);
 
     Livewire::test(FirstStepComponent::class, $firstStepState)
         ->assertSuccessful()
@@ -57,7 +57,7 @@ it('ignores initial state if property does not exist', function () {
     ])
         ->assertSuccessful();
 
-    $firstStepState = $this->wizard->getStateForStep(FirstStepComponent::class);
+    $firstStepState = $this->wizard->getStepState(FirstStepComponent::class);
 
     Livewire::test(FirstStepComponent::class, $firstStepState)
         ->assertSuccessful()

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -9,5 +9,5 @@ beforeEach(function () {
 });
 
 it('throws an exception when state cannot be found', function () {
-    $this->wizard->getStateForStep('three-thousand');
+    $this->wizard->getStepState('three-thousand');
 })->throws(StepDoesNotExist::class, 'Step `three-thousand` does not exist.');

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -1,0 +1,13 @@
+<?php
+
+use Livewire\Livewire;
+use Spatie\LivewireWizard\Exceptions\StepDoesNotExist;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\MyWizardComponent;
+
+beforeEach(function () {
+    $this->wizard = Livewire::test(MyWizardComponent::class);
+});
+
+it('throws an exception when state cannot be found', function () {
+    $this->wizard->getStateForStep('three-thousand');
+})->throws(StepDoesNotExist::class, 'Step `three-thousand` does not exist.');

--- a/tests/TestSupport/Components/Steps/FirstStepComponent.php
+++ b/tests/TestSupport/Components/Steps/FirstStepComponent.php
@@ -6,6 +6,8 @@ use Spatie\LivewireWizard\Components\StepComponent;
 
 class FirstStepComponent extends StepComponent
 {
+    public int $order = 0;
+
     public function render()
     {
         return view('test::first-step');

--- a/tests/TestSupport/TestCase.php
+++ b/tests/TestSupport/TestCase.php
@@ -55,10 +55,6 @@ class TestCase extends Orchestra
 
     public function registerLivewireTestMacros(): self
     {
-        TestableLivewire::macro('emitEvents', function () {
-            return new EventEmitter($this);
-        });
-
         TestableLivewire::macro('jsonContent', function (string $elementId) {
             $document = new DOMDocument();
 


### PR DESCRIPTION
This makes two macro's available for developers:

- `emitEvents`: can be used to pass events from `StepComponents` to the wizard.
- `getStepState`: can be used on a wizard to fetch state for a step to pass on.

I wasn't completely sure how and where to add individual tests for these macro's. Both are used in tests at this moment. It could use an exception in `getStateForStep` when a step does not exist, I can add that in a second commit (or you can merge it and add it yourself).

`getStepState` found an error in how we test the initial state. While the initial state is available in the wizard, if the public property doesn't exist in the step itself it's not going to be used. I've added an extra test for it. 