### PR TITLE
fix: move EventEmitter to src

### DIFF
--- a/src/Support/EventEmitter.php
+++ b/src/Support/EventEmitter.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace Spatie\LivewireWizard\Tests\TestSupport\Support;
+namespace Spatie\LivewireWizard\Support;
 
 use Illuminate\Support\Arr;
 use Livewire\Testing\TestableLivewire;

--- a/src/WizardServiceProvider.php
+++ b/src/WizardServiceProvider.php
@@ -8,7 +8,7 @@ use Livewire\Testing\TestableLivewire;
 use Spatie\LaravelPackageTools\Package;
 use Spatie\LaravelPackageTools\PackageServiceProvider;
 use Spatie\LivewireWizard\Exceptions\StepDoesNotExist;
-use Spatie\LivewireWizard\Tests\TestSupport\Support\EventEmitter;
+use Spatie\LivewireWizard\Support\EventEmitter;
 
 class WizardServiceProvider extends PackageServiceProvider
 {


### PR DESCRIPTION
@freekmurze sorry, I just found a bug that I missed while developing it. The `EventEmitter` class isn't available in an application as it's part of the test folder. Moving it to src makes it part of the package.

Location up for debate; feel free to change it.