### PR TITLE
tests: fetch state for steps without state

### DIFF
--- a/src/Components/WizardComponent.php
+++ b/src/Components/WizardComponent.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LivewireWizard\Components;
 
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 use Livewire\Component;
 use Livewire\Livewire;
@@ -101,10 +102,21 @@ abstract class WizardComponent extends Component
         $this->allStepState[$step] = $state;
     }
 
-    public function getCurrentStepState(): array
+    public function getCurrentStepState(?string $step = null): array
     {
+        $stepName = $step ?? $this->currentStepName;
+
+        $stepName = class_exists($stepName)
+            ? Livewire::getAlias($stepName)
+            : $stepName;
+
+        throw_if(
+            !$this->stepNames()->contains($stepName),
+            StepDoesNotExist::stepNotFound($stepName)
+        );
+
         return array_merge(
-            $this->allStepState[$this->currentStepName] ?? [],
+            $this->allStepState[$stepName] ?? [],
             [
                 'allStepNames' => $this->stepNames()->toArray(),
                 'allStepsState' => $this->allStepState,

--- a/src/WizardServiceProvider.php
+++ b/src/WizardServiceProvider.php
@@ -30,18 +30,8 @@ class WizardServiceProvider extends PackageServiceProvider
             return new EventEmitter($this);
         });
 
-        TestableLivewire::macro('getStepState', function (string $step) {
-            $state = $this->get('allStepState');
-
-            $stepName = class_exists($step)
-                ? Livewire::getAlias($step)
-                : $step;
-
-            $state = Arr::get($state, $stepName);
-
-            throw_if(is_null($state), StepDoesNotExist::stepNotFound($step));
-
-            return $state;
+        TestableLivewire::macro('getStepState', function (?string $step = null) {
+            return $this->instance()->getCurrentStepState($step);
         });
     }
 }

--- a/tests/MacroTest.php
+++ b/tests/MacroTest.php
@@ -3,6 +3,7 @@
 use Livewire\Livewire;
 use Spatie\LivewireWizard\Exceptions\StepDoesNotExist;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\MyWizardComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SecondStepComponent;
 
 beforeEach(function () {
     $this->wizard = Livewire::test(MyWizardComponent::class);
@@ -11,3 +12,9 @@ beforeEach(function () {
 it('throws an exception when state cannot be found', function () {
     $this->wizard->getStepState('three-thousand');
 })->throws(StepDoesNotExist::class, 'Step `three-thousand` does not exist.');
+
+it('gets state when no initial state is available', function () {
+    expect($this->wizard->getStepState(SecondStepComponent::class))
+        ->not
+        ->toThrow(StepDoesNotExist::class);
+});


### PR DESCRIPTION
I just found an issue while testing state for a step that has no initial state. This PR at the moment only adds a failing test.

## The problem

When there is no initial state for a step, the macro we use for fetching state throws an exception. It tries to get state for a step which has no state yet. This will also not work if a step does not have state at all, but does need access to the global state.

## Possible solutions

I see two ways to fix this.

### 1. Make sure `getStepState` works as advertised

This may require adding a parameter to `getCurrentStepState()` in the wizard. The code would look like this:

```php
public function getCurrentStepState(?string $step = null): array
{
    return array_merge(
        $this->allStepState[$step ?? $this->currentStepName] ?? [],
        [
            'allStepNames' => $this->stepNames()->toArray(),
            'allStepsState' => $this->allStepState,
            'stateClassName' => $this->stateClass(),
        ],
    );
}
```

It may be worthwhile to have this throw an exception. 

Instead of the current code, the macro would return:

```php
$this->instance()->getCurrentStepState($step);
```

There may be other viable options here; but this would be pretty clean and allows for fine grained testing. This might not even warrant having a macro, but having a macro is a bit cleaner in my opinion. This is my preferred solution.

### 2. Use what's already there

If we don't want to support getting state for specific step, we could just have developers use:

```
$wizard->instance()->getCurrentStepState()
```

And document it instead of the macro we've happed.

Not happy that this is my second PR that turns out having errors. Really sorry for that 😢 Let me know which option you prefer and I'll make sure it's sorted.