### PR TITLE
Fix missing semicolon in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ This package offers lightweight Livewire components that allow you to easily bui
 Here's what a wizard component class could look like.
 
 ```php
-use Spatie\LivewireWizard\Components\WizardComponent
+use Spatie\LivewireWizard\Components\WizardComponent;
 
 class CheckoutWizardComponent extends WizardComponent
 {


### PR DESCRIPTION
Hi Freek!

Sorry if this PR seems trivial ...

There is one missing semicolon when displaying the `use` import and it confuses the Github's code formatting as attach. ~and caused my OCD~ 
![image](https://user-images.githubusercontent.com/43839286/188081162-29ae6abc-25dd-4b1a-86dc-e87dcaab86c0.png)

It should look much prettier if we add it
![image](https://user-images.githubusercontent.com/43839286/188081578-651562b9-cf55-4f5f-836c-b12ae2f4130b.png)


Btw... i am using this package since the beginning of you publishing in development and i love it ! Thanks for this package!


