### PR TITLE
Allow the usage of auto-discovery

### DIFF
--- a/src/Components/WizardComponent.php
+++ b/src/Components/WizardComponent.php
@@ -37,19 +37,18 @@ abstract class WizardComponent extends Component
     public function stepNames(): Collection
     {
         $steps = collect($this->steps())
-            ->each(function (string $stepClassName) {
-                if (! is_a($stepClassName, StepComponent::class, true)) {
-                    throw InvalidStepComponent::doesNotExtendStepComponent(static::class, $stepClassName);
-                }
-            })
             ->map(function (string $stepClassName) {
-                $alias = Livewire::getAlias($stepClassName);
+                $class = Livewire::getClass($stepClassName);
 
-                if (is_null($alias)) {
+                if (is_null($class)) {
                     throw InvalidStepComponent::notRegisteredWithLivewire(static::class, $stepClassName);
                 }
 
-                return $alias;
+                if (! is_a($class, StepComponent::class, true)) {
+                    throw InvalidStepComponent::doesNotExtendStepComponent(static::class, $stepClassName);
+                }
+
+                return $stepClassName;
             });
 
         if ($steps->isEmpty()) {
@@ -106,7 +105,7 @@ abstract class WizardComponent extends Component
         $stepName = $step ?? $this->currentStepName;
 
         $stepName = class_exists($stepName)
-            ? Livewire::getAlias($stepName)
+            ? Livewire::getClass($stepName)
             : $stepName;
 
         throw_if(

--- a/src/Components/WizardComponent.php
+++ b/src/Components/WizardComponent.php
@@ -105,7 +105,7 @@ abstract class WizardComponent extends Component
         $stepName = $step ?? $this->currentStepName;
 
         $stepName = class_exists($stepName)
-            ? Livewire::getClass($stepName)
+            ? Livewire::getAlias($stepName)
             : $stepName;
 
         throw_if(


### PR DESCRIPTION
We're using Livewire's [auto-discovery](https://github.com/foxws/livewire-multidomain) a lot, so you don't have to register each component in a service provider.

With this change, you can now use:
```php
<?php

namespace App\Resources\Components\Wizard;

use Spatie\LivewireWizard\Components\WizardComponent;

class Onboarding extends WizardComponent
{
    public function steps(): array
    {
        return [
            'wizard.steps.user-details',
            'wizard.steps.user-billing',
        ];
    }
}
```
The `getClass` will try to find the component including in the `bootstrap` cache. The benefit is also that components aren't double registered and being loaded from the cache.

Let me know your thoughts, thanks!