### PR TITLE
fix missing text in side navigation

### DIFF
--- a/docs/usage/testing-wizards.md
+++ b/docs/usage/testing-wizards.md
@@ -55,7 +55,7 @@ We then move to the next step by calling `nextStep`. This emits an event to be
 picked up by the wizard. `emitEvents` takes the event thats emitted by `nextStep` and passes it to the
 wizard. The wizard processes it and takes you to the next step. We then assert if the second step is loaded.
 
-## Testing state in a `StepComponent`
+## Testing state in a StepComponent
 
 Now that you know how to navigate your wizard in your tests, let's talk state. 
 


### PR DESCRIPTION
It seems that code markdown is not detected when generating side navigation for this page, I changed to normal text in order to obtain a complete title

![image](https://user-images.githubusercontent.com/8792274/210773920-7a258271-e8ba-4c48-a662-2d211e975dbb.png)
