### PR TITLE
Added hasPreviousStep and hasNextStep to StepComponent

### DIFF
--- a/docs/usage/navigating-steps.md
+++ b/docs/usage/navigating-steps.md
@@ -60,6 +60,13 @@ You can also call it in your view.
 </div>
 ```
 
+You can also check if a next or previous step exists directly from the step component.
+
+```blade
+$this->hasNextStep();
+$this->hasPreviousStep();
+```
+
 ## Start at a specific step
 
 If you want the wizard to display a specific step when it is rendered first, you can pass the step name to the `show-step` property.

--- a/src/Components/StepComponent.php
+++ b/src/Components/StepComponent.php
@@ -32,6 +32,16 @@ abstract class StepComponent extends Component
         $this->emitUp('showStep', $stepName, $this->state()->currentStep());
     }
 
+    public function hasPreviousStep()
+    {
+        return $this->allStepNames[0] !== Livewire::getAlias(static::class);
+    }
+
+    public function hasNextStep()
+    {
+        return end($this->allStepNames) !== Livewire::getAlias(static::class);
+    }
+
     public function stepInfo(): array
     {
         return [];

--- a/tests/WizardTest.php
+++ b/tests/WizardTest.php
@@ -142,3 +142,17 @@ it('has a steps property to render navigation', function () {
 
     assertMatchesHtmlSnapshot($navigationHtml);
 });
+
+it('does have the correct has step states', function () {
+    $this->secondStep = Livewire::test(SecondStepComponent::class);
+    $this->thirdStep = Livewire::test(ThirdStepComponent::class);
+
+    $this->assertTrue($this->firstStep->call('hasNextStep'));
+    $this->assertFalse($this->firstStep->call('hasPreviousStep'));
+
+    $this->assertTrue($this->secondStep->call('hasNextStep'));
+    $this->assertTrue($this->secondStep->call('hasPreviousStep'));
+
+    $this->assertFalse($this->thirdStep->call('hasNextStep'));
+    $this->assertTrue($this->thirdStep->call('hasPreviousStep'));
+});


### PR DESCRIPTION
I've added functionality to be able to see if there are succeeding or preceding steps in the wizard.

This is useful because it allows you to have the following:

```
@if ($this->hasPreviousStep())
    <button wire:click="previousStep">
        {{ __('Back') }}
    </button>
@endif

@if ($this->hasNextStep())
    <button wire:click="nextStep">
        {{ __('Next') }}
    </button>
@else
    <button wire:click="submit">
        {{ __('Create') }}
    </button>
@endif
```

I do have some hardship though. I've tried testing it, but I can not get it working. I've added this to a 'parent' component that inherits from the `StepComponent` in my project, and have manually tested it. Assistance here will be appreciated - I've committed my approach to the test.