### PR TITLE
Add has step checks

### DIFF
--- a/docs/usage/navigating-steps.md
+++ b/docs/usage/navigating-steps.md
@@ -60,6 +60,13 @@ You can also call it in your view.
 </div>
 ```
 
+You can also check if a next or previous step exists directly from the step component.
+
+```blade
+$this->hasNextStep();
+$this->hasPreviousStep();
+```
+
 ## Start at a specific step
 
 If you want the wizard to display a specific step when it is rendered first, you can pass the step name to the `show-step` property.

--- a/src/Components/StepComponent.php
+++ b/src/Components/StepComponent.php
@@ -32,6 +32,16 @@ abstract class StepComponent extends Component
         $this->emitUp('showStep', $stepName, $this->state()->currentStep());
     }
 
+    public function hasPreviousStep()
+    {
+        return $this->allStepNames[0] !== Livewire::getAlias(static::class);
+    }
+
+    public function hasNextStep()
+    {
+        return end($this->allStepNames) !== Livewire::getAlias(static::class);
+    }
+
     public function stepInfo(): array
     {
         return [];

--- a/tests/WizardTest.php
+++ b/tests/WizardTest.php
@@ -142,3 +142,17 @@ it('has a steps property to render navigation', function () {
 
     assertMatchesHtmlSnapshot($navigationHtml);
 });
+
+it('does have the correct has step states', function () {
+    $this->secondStep = Livewire::test(SecondStepComponent::class);
+    $this->thirdStep = Livewire::test(ThirdStepComponent::class);
+
+    $this->assertTrue($this->firstStep->call('hasNextStep'));
+    $this->assertFalse($this->firstStep->call('hasPreviousStep'));
+
+    $this->assertTrue($this->secondStep->call('hasNextStep'));
+    $this->assertTrue($this->secondStep->call('hasPreviousStep'));
+
+    $this->assertFalse($this->thirdStep->call('hasNextStep'));
+    $this->assertTrue($this->thirdStep->call('hasPreviousStep'));
+});

--- a/tests/WizardTest.php
+++ b/tests/WizardTest.php
@@ -143,16 +143,30 @@ it('has a steps property to render navigation', function () {
     assertMatchesHtmlSnapshot($navigationHtml);
 });
 
-it('does have the correct has step states', function () {
-    $this->secondStep = Livewire::test(SecondStepComponent::class);
-    $this->thirdStep = Livewire::test(ThirdStepComponent::class);
+it('has the correct has step states', function () {
+    // Set up the step names array to match the expected steps
+    $stepNames = [
+        Livewire::getAlias(FirstStepComponent::class),
+        Livewire::getAlias(SecondStepComponent::class),
+        Livewire::getAlias(ThirdStepComponent::class),
+    ];
 
-    $this->assertTrue($this->firstStep->call('hasNextStep'));
-    $this->assertFalse($this->firstStep->call('hasPreviousStep'));
+    // Create instances of each step component and set the allStepNames property on them
+    $this->firstStep = new FirstStepComponent();
+    $this->firstStep->allStepNames = $stepNames;
 
-    $this->assertTrue($this->secondStep->call('hasNextStep'));
-    $this->assertTrue($this->secondStep->call('hasPreviousStep'));
+    $this->secondStep = new SecondStepComponent();
+    $this->secondStep->allStepNames = $stepNames;
 
-    $this->assertFalse($this->thirdStep->call('hasNextStep'));
-    $this->assertTrue($this->thirdStep->call('hasPreviousStep'));
+    $this->thirdStep = new ThirdStepComponent();
+    $this->thirdStep->allStepNames = $stepNames;
+
+    $this->assertFalse($this->firstStep->hasPreviousStep());
+    $this->assertTrue($this->firstStep->hasNextStep());
+
+    $this->assertTrue($this->secondStep->hasPreviousStep());
+    $this->assertTrue($this->secondStep->hasNextStep());
+
+    $this->assertTrue($this->thirdStep->hasPreviousStep());
+    $this->assertFalse($this->thirdStep->hasNextStep());
 });

--- a/tests/WizardTest.php
+++ b/tests/WizardTest.php
@@ -161,12 +161,12 @@ it('has the correct has step states', function () {
     $this->thirdStep = new ThirdStepComponent();
     $this->thirdStep->allStepNames = $stepNames;
 
-    $this->assertFalse($this->firstStep->hasPreviousStep());
-    $this->assertTrue($this->firstStep->hasNextStep());
+    expect($this->firstStep->hasPreviousStep())->toBeFalse();
+    expect($this->firstStep->hasNextStep())->toBeTrue();
 
-    $this->assertTrue($this->secondStep->hasPreviousStep());
-    $this->assertTrue($this->secondStep->hasNextStep());
+    expect($this->secondStep->hasPreviousStep())->toBeTrue();
+    expect($this->secondStep->hasNextStep())->toBeTrue();
 
-    $this->assertTrue($this->thirdStep->hasPreviousStep());
-    $this->assertFalse($this->thirdStep->hasNextStep());
+    expect($this->thirdStep->hasPreviousStep())->toBeTrue();
+    expect($this->thirdStep->hasNextStep())->toBeFalse();
 });


### PR DESCRIPTION
I've added functionality to be able to see if there are succeeding or preceding steps in the wizard.

This is useful because it allows you to have the following:

```
@if ($this->hasPreviousStep())
    <button wire:click="previousStep">
        {{ __('Back') }}
    </button>
@endif

@if ($this->hasNextStep())
    <button wire:click="nextStep">
        {{ __('Next') }}
    </button>
@else
    <button wire:click="submit">
        {{ __('Create') }}
    </button>
@endif
```

This is a new PR related to https://github.com/spatie/laravel-livewire-wizard/pull/76