### PR TITLE
Fixed bug where tests would fail

### DIFF
--- a/src/Components/StepComponent.php
+++ b/src/Components/StepComponent.php
@@ -34,7 +34,7 @@ abstract class StepComponent extends Component
 
     public function hasPreviousStep()
     {
-        return $this->allStepNames[0] !== Livewire::getAlias(static::class);
+        return !empty($this->allStepNames) && $this->allStepNames[0] !== Livewire::getAlias(static::class);
     }
 
     public function hasNextStep()


### PR DESCRIPTION
This fixes a bug where tests would fail after the latest update.

If the test for the whole wizard isn't set up the way tests in this package is set up, it will fail the tests. This is because `Livewire::test` doesn't properly build the wizard with the steps.