### PR TITLE
Provide default value so failing tests don't crash

### DIFF
--- a/src/Support/EventEmitter.php
+++ b/src/Support/EventEmitter.php
@@ -13,7 +13,7 @@ class EventEmitter
 
     public function in(TestableLivewire $component): TestableLivewire
     {
-        $events = Arr::get($this->emittingComponent->payload, 'effects.emits');
+        $events = Arr::get($this->emittingComponent->payload, 'effects.emits', []);
 
         foreach ($events as $event) {
             $component->emit($event['event'], ...$event['params']);


### PR DESCRIPTION
Hello 👋

This PR adds an `iterable` as the default value to fix the following issue in failing tests:

```
ErrorException: foreach() argument must be of type array|object, null given
/Users/masari/Sites/redacted/vendor/laravel/framework/src/Illuminate/Foundation/Bootstrap/HandleExceptions.php:254
/Users/masari/Sites/redacted/vendor/spatie/laravel-livewire-wizard/src/Support/EventEmitter.php:18
/Users/masari/Sites/redacted/tests/Feature/WizardTest.php:102
/Users/masari/Sites/redacted/vendor/laravel/framework/src/Illuminate/Foundation/Testing/TestCase.php:174
```

It'd be better to receive a failing assertion instead of a runtime exception:

```
Failed asserting that '...' contains "Step 2/3".
```

Thanks! 🙌