### PR TITLE
Fixes step navigation when there are multiple wizards on a page

### DIFF
--- a/src/Components/StepComponent.php
+++ b/src/Components/StepComponent.php
@@ -11,6 +11,8 @@ abstract class StepComponent extends Component
 {
     use StepAware;
 
+    public string $wizardComponentName;
+
     public array $allStepNames = [];
     public array $allStepsState = [];
 
@@ -19,17 +21,17 @@ abstract class StepComponent extends Component
 
     public function previousStep()
     {
-        $this->dispatch('previousStep', $this->state()->currentStep());
+        $this->dispatch('previousStep', $this->state()->currentStep())->to($this->wizardComponentName);
     }
 
     public function nextStep()
     {
-        $this->dispatch('nextStep', $this->state()->currentStep());
+        $this->dispatch('nextStep', $this->state()->currentStep())->to($this->wizardComponentName);
     }
 
     public function showStep(string $stepName)
     {
-        $this->dispatch('showStep', toStepName: $stepName, currentStepState: $this->state()->currentStep());
+        $this->dispatch('showStep', toStepName: $stepName, currentStepState: $this->state()->currentStep())->to($this->wizardComponentName);
     }
 
     public function hasPreviousStep()

--- a/src/Components/StepComponent.php
+++ b/src/Components/StepComponent.php
@@ -11,7 +11,7 @@ abstract class StepComponent extends Component
 {
     use StepAware;
 
-    public string $wizardComponentName;
+    public ?string $wizardClassName = null;
 
     public array $allStepNames = [];
     public array $allStepsState = [];
@@ -21,17 +21,17 @@ abstract class StepComponent extends Component
 
     public function previousStep()
     {
-        $this->dispatch('previousStep', $this->state()->currentStep())->to($this->wizardComponentName);
+        $this->dispatch('previousStep', $this->state()->currentStep())->to($this->wizardClassName);
     }
 
     public function nextStep()
     {
-        $this->dispatch('nextStep', $this->state()->currentStep())->to($this->wizardComponentName);
+        $this->dispatch('nextStep', $this->state()->currentStep())->to($this->wizardClassName);
     }
 
     public function showStep(string $stepName)
     {
-        $this->dispatch('showStep', toStepName: $stepName, currentStepState: $this->state()->currentStep())->to($this->wizardComponentName);
+        $this->dispatch('showStep', toStepName: $stepName, currentStepState: $this->state()->currentStep())->to($this->wizardClassName);
     }
 
     public function hasPreviousStep()

--- a/src/Components/WizardComponent.php
+++ b/src/Components/WizardComponent.php
@@ -118,6 +118,7 @@ abstract class WizardComponent extends Component
                 'allStepNames' => $this->stepNames()->toArray(),
                 'allStepsState' => $this->allStepState,
                 'stateClassName' => $this->stateClass(),
+                'wizardComponentName' => $this->getName(),
             ],
         );
     }

--- a/src/Components/WizardComponent.php
+++ b/src/Components/WizardComponent.php
@@ -118,7 +118,7 @@ abstract class WizardComponent extends Component
                 'allStepNames' => $this->stepNames()->toArray(),
                 'allStepsState' => $this->allStepState,
                 'stateClassName' => $this->stateClass(),
-                'wizardComponentName' => $this->getName(),
+                'wizardClassName' => static::class,
             ],
         );
     }


### PR DESCRIPTION
Changed the step navigation events to directly dispatch to the step's wizard component. This way navigating between steps still works properly when there are multiple wizards on a page.