### PR TITLE
Make setStepState update the current step's state right away

### DIFF
--- a/src/Components/StepComponent.php
+++ b/src/Components/StepComponent.php
@@ -2,6 +2,7 @@
 
 namespace Spatie\LivewireWizard\Components;
 
+use Livewire\Attributes\On;
 use Livewire\Component;
 use Livewire\Mechanisms\ComponentRegistry;
 use Spatie\LivewireWizard\Components\Concerns\StepAware;
@@ -18,6 +19,14 @@ abstract class StepComponent extends Component
 
     /** @var class-string<State> */
     public string $stateClassName = State::class;
+
+    #[On('updateState')]
+    public function updateState($state): void
+    {
+        unset($state['steps']);
+
+        $this->fill($state);
+    }
 
     public function previousStep()
     {

--- a/src/Components/WizardComponent.php
+++ b/src/Components/WizardComponent.php
@@ -97,6 +97,10 @@ abstract class WizardComponent extends Component
         }
 
         $this->allStepState[$step] = $state;
+
+        if ($step === $this->currentStepName) {
+            $this->dispatch('updateState', $state)->to($step);
+        }
     }
 
     public function getCurrentStepState(?string $step = null): array


### PR DESCRIPTION
I'm using this package to build a reusable edit modal with multiple steps. I ran into an issue when setting a new state for every step from the wizard component. The issue is that the first step will always keep its initial state as it was already rendered. Updating the state of the current step right away fixes this.

Thought I'd pr my fix for this in. If this fix isn't wanted or this isn't the right way of fixing this issue be sure to let me know or close the pr :)