### PR TITLE
Adds support for getting progress on individual steps

### DIFF
--- a/src/Components/Concerns/MountsWizard.php
+++ b/src/Components/Concerns/MountsWizard.php
@@ -7,7 +7,7 @@ use Spatie\LivewireWizard\Support\State;
 
 trait MountsWizard
 {
-    public function mountMountsWizard(?string $showStep = null, array $initialState = null)
+    public function mountMountsWizard(?string $showStep = null, ?array $initialState = null)
     {
         $stepName = $showStep ?? $this->currentStepName ?? $this->stepNames()->first();
 
@@ -21,6 +21,6 @@ trait MountsWizard
 
         if (! is_a($this->stateClass(), State::class, true)) {
             throw InvalidStateClassName::doesNotExtendState(static::class, $this->stateClass());
-        };
+        }
     }
 }

--- a/src/Components/Concerns/StepAware.php
+++ b/src/Components/Concerns/StepAware.php
@@ -10,6 +10,8 @@ trait StepAware
 {
     public array $steps = [];
 
+    public float $progress = 0;
+
     public function bootedStepAware()
     {
         $currentFound = false;
@@ -24,7 +26,6 @@ trait StepAware
 
                 $status = $currentFound ? StepStatus::Next : StepStatus::Previous;
 
-
                 if ($stepName === $currentStepName) {
                     $currentFound = true;
                     $status = StepStatus::Current;
@@ -33,5 +34,19 @@ trait StepAware
                 return new Step($stepName, $info, $status);
             })
             ->toArray();
+
+        $this->getProgress();
+    }
+
+    public function getProgress(): float
+    {
+        $steps = collect($this->steps);
+        $totalSteps = $steps->count() - 1;
+
+        $index = $steps->search(fn (Step $step) => $step->stepName === $this->getName());
+
+        return $this->progress = $totalSteps > 0
+            ? round(abs($index / $totalSteps), 2)
+            : 0;
     }
 }

--- a/tests/TestSupport/TestCase.php
+++ b/tests/TestSupport/TestCase.php
@@ -25,7 +25,7 @@ class TestCase extends Orchestra
 
         config()->set('app.key', '6rE9Nz59bGRbeMATftriyQjrpF7DcOQm');
 
-        View::addNamespace('test', __DIR__ . '/resources/views');
+        View::addNamespace('test', __DIR__.'/resources/views');
 
         $this
             ->registerLivewireComponents()

--- a/tests/WizardTest.php
+++ b/tests/WizardTest.php
@@ -5,6 +5,7 @@ use Livewire\Mechanisms\ComponentRegistry;
 use Spatie\LivewireWizard\Exceptions\NoNextStep;
 use Spatie\LivewireWizard\Exceptions\NoPreviousStep;
 use Spatie\LivewireWizard\Exceptions\StepDoesNotExist;
+use Spatie\LivewireWizard\Support\Step;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\MyWizardComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SecondStepComponent;
@@ -184,4 +185,43 @@ it('has the correct has step states', function () {
 
     expect($this->thirdStep->hasPreviousStep())->toBeTrue();
     expect($this->thirdStep->hasNextStep())->toBeFalse();
+});
+
+it('can properly determine the step progress', function () {
+    // Set up the step names array to match the expected steps
+    $stepNames = [
+        app(ComponentRegistry::class)->getName(FirstStepComponent::class),
+        app(ComponentRegistry::class)->getName(SecondStepComponent::class),
+        app(ComponentRegistry::class)->getName(ThirdStepComponent::class),
+    ];
+
+    // Setup components
+    $this->firstStep = new FirstStepComponent();
+    $this->firstStep->allStepNames = $stepNames;
+    $this->firstStep->setName('first-step');
+    $this->firstStep->bootedStepAware();
+
+    $this->secondStep = new SecondStepComponent();
+    $this->secondStep->allStepNames = $stepNames;
+    $this->secondStep->setName('second-step');
+    $this->secondStep->bootedStepAware();
+
+    $this->thirdStep = new ThirdStepComponent();
+    $this->thirdStep->allStepNames = $stepNames;
+    $this->thirdStep->setName('third-step');
+    $this->thirdStep->bootedStepAware();
+
+    // Get progress
+    $firstStepProgress = $this->firstStep->getProgress();
+    $secondStepProgress = $this->secondStep->getProgress();
+    $thirdStepProgress = $this->thirdStep->getProgress();
+
+    expect($this->firstStep->progress)->toBe(0.0);
+    expect($firstStepProgress)->toBe(0.0);
+
+    expect($this->secondStep->progress)->toBe(0.5);
+    expect($secondStepProgress)->toBe(0.5);
+
+    expect($this->thirdStep->progress)->toBe(1.0);
+    expect($thirdStepProgress)->toBe(1.0);
 });

--- a/tests/__snapshots__/WizardTest__it_has_a_steps_property_to_render_navigation__1.html
+++ b/tests/__snapshots__/WizardTest__it_has_a_steps_property_to_render_navigation__1.html
@@ -1,12 +1,12 @@
 <html><body><div id="navigation">
         This is navigation
         <ul>
-            <!-- __BLOCK__ -->                In step
+            <!--[if BLOCK]><![endif]-->                In step
                 <li class="" wire:click="showStep('first-step')">First step</li>
                             In step
                 <li class="text-bold">Second step</li>
                             In step
                 <li class="">Third step</li>
-             <!-- __ENDBLOCK__ -->
+             <!--[if ENDBLOCK]><![endif]-->
         </ul>
     </div></body></html>


### PR DESCRIPTION
The following PR adds a new property to the step classes that allows a user to determine the progress through the wizard. The property is set during the boot up procedure of the StepAware trait. I've added tests to the current suite as well. 

I am looking for suggestions if this is the best place to put the logic - or should it be in the base Step component class? Also, should we add a method on the form class to determine progress overall using the currentStepName property? Thanks for the feedback!