### PR TITLE
add forStepClass method to get state more convenient

### DIFF
--- a/docs/usage/accessing-state.md
+++ b/docs/usage/accessing-state.md
@@ -15,6 +15,7 @@ On that state object you can call these methods:
 
 - `all()`: returns an array containing the values of all public properties of all steps in the wizard. The key of the items in the array is the name of the step. Optionally, you can pass is a key name to let the function only return the value for that key.
 - `forStep($stepname)`:  returns the values of all public properties of the given step.
+- `forStepClass(StepComponent::class)`: similar to `forStep`, but you can pass in the class name of the step component.
 - `currentStep()`: returns an array containing the values of all public properties of the current step. The result is almost identical to Livewire's native `all()` method, but with some internal properties filtered out.
 
 ```php
@@ -22,6 +23,7 @@ On that state object you can call these methods:
 
 $this->state()->all(); // returns all state from all steps in the wizard
 $this->state()->forStep('delivery-address-step'); // returns all state of the given step
+$this->state()->forStepClass(App\Livewire\DevliveryAddressStep::class);
 $this->state()->currentStep(); // returns all state of the current step
 ```
 

--- a/src/Support/State.php
+++ b/src/Support/State.php
@@ -37,7 +37,7 @@ class State
 
     public function forStepClass(string $stepClass): array
     {
-        $stepName = app(ComponentRegistry::class)->getClass($stepClass);
+        $stepName = app(ComponentRegistry::class)->getName($stepClass);
 
         return $this->forStep($stepName);
     }

--- a/src/Support/State.php
+++ b/src/Support/State.php
@@ -3,6 +3,7 @@
 namespace Spatie\LivewireWizard\Support;
 
 use Illuminate\Support\Arr;
+use Livewire\Mechanisms\ComponentRegistry;
 
 class State
 {
@@ -32,6 +33,13 @@ class State
         }
 
         return $state;
+    }
+
+    public function forStepClass(string $stepClass): array
+    {
+        $stepName = app(ComponentRegistry::class)->getClass($stepClass);
+
+        return $this->forStep($stepName);
     }
 
     public function get(string $key)

--- a/tests/StateClassTest.php
+++ b/tests/StateClassTest.php
@@ -47,5 +47,8 @@ it('can load state from different steps', function () {
             $livewireComponent = $testableLivewire->instance();
             $state = $livewireComponent->state()->forStep('first-step');
             expect($state['order'])->toBe(1029);
+
+            $state = $livewireComponent->state()->forStepClass(FirstStepComponent::class);
+            expect($state['order'])->toBe(1029);
         });
 });

--- a/tests/__snapshots__/WizardTest__it_has_a_steps_property_to_render_navigation__1.html
+++ b/tests/__snapshots__/WizardTest__it_has_a_steps_property_to_render_navigation__1.html
@@ -1,12 +1,12 @@
 <html><body><div id="navigation">
         This is navigation
         <ul>
-            <!-- __BLOCK__ -->                In step
+            <!--[if BLOCK]><![endif]-->                In step
                 <li class="" wire:click="showStep('first-step')">First step</li>
                             In step
                 <li class="text-bold">Second step</li>
                             In step
                 <li class="">Third step</li>
-             <!-- __ENDBLOCK__ -->
+            <!--[if ENDBLOCK]><![endif]-->
         </ul>
     </div></body></html>


### PR DESCRIPTION
Hi,

This `forStepClass` is similar to the `forStep` method to get the state for a specific step, but it uses a component class, which is not the component name. So it could be easy to autocomplete by the IDE, or in case we have many component registries in a package for long names like `package:namespace.feature.steps.options-step`.

And by the way the name of the Step component registered in the service provider is used nowhere in view, so sometimes it could leak to an error when trying to refactor the class component, tho.

This is an addition, so there is no breaking change