### PR TITLE
merge initialStep with allStepState

### DIFF
--- a/src/Components/Concerns/MountsWizard.php
+++ b/src/Components/Concerns/MountsWizard.php
@@ -11,7 +11,9 @@ trait MountsWizard
     {
         $stepName = $showStep ?? $this->currentStepName ?? $this->stepNames()->first();
 
-        $initialState = $initialState ?? array_merge($this->initialState() ?? [], $this->allStepState) ?? [];
+        $initialState = $initialState ?? $this->initialState() ?? [];
+
+        $initialState = array_merge($initialState, $this->allStepState);
 
         $this->showStep($stepName, $initialState[$stepName] ?? []);
 

--- a/src/Components/Concerns/MountsWizard.php
+++ b/src/Components/Concerns/MountsWizard.php
@@ -11,7 +11,7 @@ trait MountsWizard
     {
         $stepName = $showStep ?? $this->currentStepName ?? $this->stepNames()->first();
 
-        $initialState = $initialState ?? $this->initialState() ?? [];
+        $initialState = $initialState ?? array_merge($this->initialState() ?? [], $this->allStepState) ?? [];
 
         $this->showStep($stepName, $initialState[$stepName] ?? []);
 

--- a/tests/InitialStateTest.php
+++ b/tests/InitialStateTest.php
@@ -1,5 +1,6 @@
 <?php
 
+use Livewire\Features\SupportTesting\Testable;
 use Livewire\Livewire;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\WizardWithInitialState;
@@ -62,4 +63,15 @@ it('ignores initial state if property does not exist', function () {
     Livewire::test(FirstStepComponent::class, $firstStepState)
         ->assertSuccessful()
         ->assertNotSet('name', 'Freek');
+});
+
+it('state is not persisted when wizard recreated', function () {
+    $this->wizard->call('setStepState', 'first-step', ['order' => 456]);
+
+    $wizard = Testable::create(WizardWithInitialState::class, [
+        'order' => 123,
+    ]);
+
+    Livewire::test(FirstStepComponent::class, $wizard->getStepState(FirstStepComponent::class))
+        ->assertSet('order', 123);
 });

--- a/tests/PersistStateTest.php
+++ b/tests/PersistStateTest.php
@@ -1,0 +1,34 @@
+<?php
+
+use Livewire\Features\SupportTesting\Testable;
+use Livewire\Livewire;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\WizardWithPersistState;
+
+
+it('can restore the persisted state', function () {
+    $wizard = Testable::create(WizardWithPersistState::class, [
+        'initialState' => [
+            'first-step' => [
+                'order' => 123
+            ]
+        ]
+    ]);
+
+    $wizard->call('setStepState', 'first-step', ['order' => 456]);
+
+    Livewire::test(FirstStepComponent::class, $wizard->getStepState(FirstStepComponent::class))
+        ->assertSet('order', 456);
+
+    // recreate the wizard
+    $wizard = Testable::create(WizardWithPersistState::class, [
+        'initialState' => [
+            'first-step' => [
+                'order' => 123
+            ]
+        ]
+    ]);
+
+    Livewire::test(FirstStepComponent::class, $wizard->getStepState(FirstStepComponent::class))
+        ->assertSet('order', 456);
+});

--- a/tests/TestSupport/Components/WizardWithPersistState.php
+++ b/tests/TestSupport/Components/WizardWithPersistState.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Spatie\LivewireWizard\Tests\TestSupport\Components;
+
+use Livewire\Attributes\Layout;
+use Livewire\Attributes\Session;
+use Spatie\LivewireWizard\Components\WizardComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SecondStepComponent;
+
+#[Layout('test::layout')]
+class WizardWithPersistState extends WizardComponent
+{
+    #[Session]
+    public array $allStepState = [];
+
+    public function steps(): array
+    {
+        return [
+            FirstStepComponent::class,
+            SecondStepComponent::class,
+        ];
+    }
+
+    public function initialState(): ?array
+    {
+        return [
+            'first-step' => [
+                'order' => 123
+            ]
+        ];
+    }
+}

--- a/tests/TestSupport/Components/WizardWithPersistState.php
+++ b/tests/TestSupport/Components/WizardWithPersistState.php
@@ -2,13 +2,11 @@
 
 namespace Spatie\LivewireWizard\Tests\TestSupport\Components;
 
-use Livewire\Attributes\Layout;
 use Livewire\Attributes\Session;
 use Spatie\LivewireWizard\Components\WizardComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SecondStepComponent;
 
-#[Layout('test::layout')]
 class WizardWithPersistState extends WizardComponent
 {
     #[Session]


### PR DESCRIPTION
This will allow we use the `Livewire\Attributes\Session` to persists the state of the Wizard component, combine with `#[Url]` for `$currentStepName`, this could help us reload the current step of wizard without losing data.

```php

use Livewire\Attributes\Session;
use Livewire\Attributes\Url;
use Spatie\LivewireWizard\Components\WizardComponent;

class WizardWithPersistState extends WizardComponent
{
    #[Session]
    public array $allStepState = [];

    #[Url]
    public ?string $currentStepName = '';
```