### PR TITLE
Add alternative package to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ Our package is headless. This means that it does not provide UI, but it offers f
 
 [Filament](https://filamentphp.com) users could also take a look at [the built-in wizard functionality](https://filamentphp.com/docs/2.x/forms/layout#wizard).
 
+Another headless package [satoved/laravel-livewire-steps](https://github.com/satoved/laravel-livewire-steps) that uses Livewire form objects for steps instead of Livewire components can be considered for simpler use cases.
+
 ## Changelog
 
 Please see [CHANGELOG](CHANGELOG.md) for more information on what has changed recently.


### PR DESCRIPTION
Thanks for a great package, I've used it on many projects.

It served me well, but over time I found several things that started to bug me:

- Passing state from step to step is complex
- When quickly switching steps, sometimes two livewire components fail to sync, which results in 500
- Testing wizard is cumbersome
- Impossible to skip steps
- Network lag because of two network request required for each step change

I tried to take a different approach to the problem. Wizard is the only Livewire component required, and Steps are presented as Livewire form objects that also can render themselves.

Package: https://github.com/satoved/laravel-livewire-steps
Demo app: https://github.com/satoved/laravel-livewire-steps-demo