### PR TITLE
Make nullable parameter type hint explicitly nullable

### DIFF
--- a/src/Components/Concerns/MountsWizard.php
+++ b/src/Components/Concerns/MountsWizard.php
@@ -7,7 +7,7 @@ use Spatie\LivewireWizard\Support\State;
 
 trait MountsWizard
 {
-    public function mountMountsWizard(?string $showStep = null, array $initialState = null)
+    public function mountMountsWizard(?string $showStep = null, ?array $initialState = null)
     {
         $stepName = $showStep ?? $this->currentStepName ?? $this->stepNames()->first();
 


### PR DESCRIPTION
Is solves the following deprecation message in PHP 8.4:

`Deprecated: Spatie\LivewireWizard\Components\Concerns\MountsWizard::mountMountsWizard(): Implicitly marking parameter $initialState as nullable is deprecated, the explicit nullable type must be used instead in vendor/spatie/laravel-livewire-wizard/src/Components/Concerns/MountsWizard.php on line 10`