### PR TITLE
Authorization inside a wizard

### DIFF
--- a/tests/TestStepMacroTest.php
+++ b/tests/TestStepMacroTest.php
@@ -3,6 +3,7 @@
 use Spatie\LivewireWizard\Tests\TestSupport\Components\MyWizardComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
 use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SecondStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\WizardWithAuth;
 
 it('can test a step without state', function () {
     MyWizardComponent::testStep(FirstStepComponent::class)
@@ -25,3 +26,11 @@ it('cannot test a step with invalid initial state', function () {
         ],
     ]);
 })->throws(Exception::class);
+
+it('handles unauthorized actions gracefully', function () {
+    WizardWithAuth::testStep(FirstStepComponent::class, [
+        'first-step' => [
+            'order' => 220,
+        ],
+    ])->assertForbidden();
+});

--- a/tests/TestSupport/Components/WizardWithAuth.php
+++ b/tests/TestSupport/Components/WizardWithAuth.php
@@ -1,0 +1,27 @@
+<?php
+
+namespace Spatie\LivewireWizard\Tests\TestSupport\Components;
+
+use Illuminate\Support\Facades\Gate;
+use Spatie\LivewireWizard\Components\WizardComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\FirstStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\SecondStepComponent;
+use Spatie\LivewireWizard\Tests\TestSupport\Components\Steps\ThirdStepComponent;
+
+class WizardWithAuth extends WizardComponent
+{
+    public function mount(): void
+    {
+        // Instead of using a gate, I'm forcing an unauthorized action
+        abort(403, 'Unauthorized action.');
+    }
+
+    public function steps(): array
+    {
+        return [
+            FirstStepComponent::class,
+            SecondStepComponent::class,
+            ThirdStepComponent::class,
+        ];
+    }
+}


### PR DESCRIPTION
We would like to be able to handle authorization inside our wizard. There's nothing preventing that at the moment, but it's impossible to test. In fact, you have to remove the authorization to run any test at all.

You get the following error:

```
 FAILED  Tests\TestStepMacroTest > it handles unauthor…  ReflectionException
  Class "" does not exist
```

I have added a failing test in this PR. I'm not sure what the solution is at the moment.